### PR TITLE
Categories: Defined Quarto version for GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: '1.5.57' # Specify the desired version
 
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@v2

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ index.ipynb
 index.md
 index_files/
 index.tex
+
+# Prevents committing locally rendered site
+docs


### PR DESCRIPTION
Sadly, PR #10 didn't fix the issue, but it also didn't hurt anything adding the `.nojekyll` file. 

The root of the issues is that a bug was introduced when they added support for categories with non ASCII characters with base64 encoding. The GitHub actions by default uses Quarto 1.6.40, which includes the bug. The Quarto team is working on the issue and I think have resolved it for some 1.7.* release. In the meantime I've set the the version of Quarto used by GitHub actions to 1.5.57 because I know it works fine with that version.

* https://github.com/quarto-dev/quarto-cli/pull/11771
* https://github.com/quarto-dev/quarto-cli/pull/11869

