### PR TITLE
Add CNAME file

### DIFF
--- a/.github/CNAME
+++ b/.github/CNAME
@@ -1,0 +1,1 @@
+grass-tutorials.osgeo.org


### PR DESCRIPTION
CNAME is needed when you publish from a (gh-pages) branch with custom domain. In that case, the GitHub settings only creates a commit on the specified branch. In our case, gh-pages is build from main, but main does not have CNAME so the GitHub-created one was removed on every update. This adds the CNAME file added by GitHub to gh-pages to main.

The GitHub interface creates CNAME commit after custom domain settings in the background without telling the user, so I didn't make the connection to the CNAME discussion in the doc. Anyway, here is the relevant doc:

https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain
https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages

Any idea if these extra files are just copied over from main to gh-pages? `.nojekyll` seems to be.