### PR TITLE
CI: Updated gh action deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
               version: '1.5.57' # Specify the desired version
 
           - name: Render Quarto Project
-            uses: quarto-dev/quarto-actions/render@v2`
+            uses: quarto-dev/quarto-actions/render@v2
 
           - name: Upload static files as artifact
             uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,22 +6,39 @@ on:
 name: Quarto Publish
 
 jobs:
-  build-deploy:
-    runs-on: ubuntu-latest
+  build:
+      runs-on: ubuntu-latest
+      permissions:
+          contents: write
+      steps:
+          - name: Check out repository
+            uses: actions/checkout@v4
+  
+          - name: Set up Quarto
+            uses: quarto-dev/quarto-actions/setup@v2
+            with:
+              version: '1.5.57' # Specify the desired version
+
+          - name: Upload static files as artifact
+            uses: actions/upload-pages-artifact@v3
+            with:
+              path: docs/
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Deployment job
+  deploy:
     permissions:
-      contents: write
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: '1.5.57' # Specify the desired version
-
-      - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
-        with:
-          target: gh-pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ jobs:
             with:
               version: '1.5.57' # Specify the desired version
 
+          - name: Render Quarto Project
+            uses: quarto-dev/quarto-actions/render@v2`
+
           - name: Upload static files as artifact
             uses: actions/upload-pages-artifact@v3
             with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,6 @@ jobs:
             uses: actions/upload-pages-artifact@v3
             with:
               path: docs/
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Deployment job
   deploy:
@@ -43,5 +41,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've update the the publish action to use GitHub artifacts as discussed in issue #19 . 

To implement we need to change the repository configuration in **Settings > Pages** by switching the source to **GitHub Actions**.