### PR TITLE
Fixed path of navbar icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ docs
 *.Rproj
 *.Rhistory
 .Rproj.user
+
+/.luarc.json
+

--- a/_quarto-production.yml
+++ b/_quarto-production.yml
@@ -1,6 +1,5 @@
 project:
   render: 
     - "*.qmd"
-    - "!content/tests/"
 execute:
   freeze: false

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -65,7 +65,6 @@ format:
     toc-title: Table of Contents
     link-external-newwindow: true
 
-brand: _brand.yml
+brand: brand/_brand.yml
 profile:
   default: local
-  

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,6 +1,5 @@
 grass:
   name: GRASS
-  version: 8.4
   website: https://grass.osgeo.org
   support: https://opencollective.com/grass/contribute
   description: Bringing advanced geospatial technologies to the world

--- a/brand/_brand.yml
+++ b/brand/_brand.yml
@@ -14,22 +14,22 @@ meta:
 logo:
   images: 
     logo-small-no-text-light:
-      path: ../../images/logos/small/grass-logo-white-simple@05x.png
+      path: ../images/logos/small/grass-logo-white-simple@05x.png
       alt: "Small sized GRASS icon colored white with GRASS shape"
     logo-small-no-text-dark:
-      path: ../../images/logos/small/grass-logo-green-simple@05x.png
+      path: ../images/logos/small/grass-logo-green-simple@05x.png
       alt: "Small sized GRASS icon colored GRASS green with GRASS shape"
     logo-medium-no-text-light:
-      path: ../../images/logos/medium/grass-logo-white-simple@1x.png
+      path: ../images/logos/medium/grass-logo-white-simple@1x.png
       alt: "Medium sized GRASS icon colored white with GRASS shape"
     logo-medium-no-text-dark:
-      path: ../../images/logos/medium/grass-logo-green-simple@1x.png
+      path: ../images/logos/medium/grass-logo-green-simple@1x.png
       alt: "Medium sized GRASS icon colored GRASS green with GRASS shape"
     logo-large-no-text-light:
-      path: ../../images/logos/large/grass-white-no-text.svg
+      path: ../images/logos/large/grass-white-no-text.svg
       alt: "Large vector (svg) GRASS icon colored white with GRASS shape"
     logo-large-no-text-dark:
-      path: ../../images/logos/large/grass-green-no-text.svg
+      path: ../images/logos/large/grass-green-no-text.svg
       alt: "Large vector (svg) GRASS icon colored GRASS green with GRASS shape"
   small:
     light: logo-small-no-text-light

--- a/content/tests/styling.qmd
+++ b/content/tests/styling.qmd
@@ -992,10 +992,10 @@ Quarto supports several shortcodes natively which allow us to access project var
 You can access variables located in `_variables.yml` using pre-defined [varible shortcodes](https://quarto.org/docs/authoring/variables.html).
 
 ``` {.markdown shortcodes="false"}
-{{< var grass.version >}}
+{{< var grass.website >}}
 ```
 
-Will render {{< var grass.version >}}
+Will render {{< var grass.website >}}
 
 ## Includes
 
@@ -1021,14 +1021,3 @@ and finally displays
 
 {{< include /content/include/_support-button.qmd >}}
 
-## Brand
-
-Brand data is defined in the `_brand.yml` file.
-
-### Logo small light
-
-``` {.markdown shortcodes="false"}
-{{< brand logo small light >}}
-```
-
-{{< brand logo small light >}}

--- a/index.qmd
+++ b/index.qmd
@@ -1,10 +1,6 @@
 ---
 title: "Learn GRASS"
 listing:
-    - id: tests
-      contents:
-        - content/tests/styling.qmd
-      type: grid   
     - id: get-started
       contents: content/tutorials/get_started
       type: grid
@@ -33,10 +29,4 @@ title-block-banner: false
 
 ## All Tutorials
 :::{#all}
-:::
-
-::: {.content-visible when-profile="local"}
-## Tests
-:::{#tests}
-:::
 :::


### PR DESCRIPTION
Fixed issue with the path of the nav icon not rendering correctly when the site is built for production. I also removed the GRASS version from the variables and changed the styling.qmd page to render for production but only accessible via a direct link.