### PR TITLE
Fix display of description tag from yaml

### DIFF
--- a/content/tutorials/external/FUTURES.qmd
+++ b/content/tutorials/external/FUTURES.qmd
@@ -9,7 +9,7 @@ format:
     code-copy: true
     code-fold: false
 categories: [advanced, Python, R, external]
-description: This workshop introduces GRASS GIS and FUTURES urban growth modeling framework
+description: This workshop introduces GRASS and the FUTURES urban growth modeling framework.
 execute: 
   eval: false
 ---

--- a/content/tutorials/external/GIS_for_designers.qmd
+++ b/content/tutorials/external/GIS_for_designers.qmd
@@ -9,7 +9,7 @@ format:
     code-copy: true
     code-fold: false
 categories: [beginner, intermediate, GUI, Python, course, external]
-description: A course on GIS for landscape architects, urban planners, and other designers
+description: A course on GIS for landscape architects, urban planners, and other designers using GRASS.
 execute: 
   eval: false
 ---

--- a/content/tutorials/external/NCSU_GIS582.qmd
+++ b/content/tutorials/external/NCSU_GIS582.qmd
@@ -9,6 +9,7 @@ format:
     code-copy: true
     code-fold: false
 categories: [course, external, beginner, intermediate]
+description: Geospatial Modeling and Analysis course taught at NCSU. Several topics are covered with GRASS.
 execute: 
   eval: false
 ---

--- a/content/tutorials/external/ecodiv.qmd
+++ b/content/tutorials/external/ecodiv.qmd
@@ -9,7 +9,7 @@ format:
     code-copy: true
     code-fold: false
 categories: [beginner, intermediate, advanced, GUI, Python, R, external, ecology, statistics, visualization, biodiversity]
-description: GRASS tutorials on ecology and biogeography topics
+description: GRASS tutorials on ecology and biogeography topics.
 execute: 
   eval: false
 ---

--- a/content/tutorials/external/ecodiv.yml
+++ b/content/tutorials/external/ecodiv.yml
@@ -3,26 +3,26 @@
   author: Paulo van Breugel
   image: content/tutorials/external/images/sdm_in_grass_tutorialbanner.png
   date: "2025-02-12"
-  description: Creating species distribution models to predicting the current and future distribution of the Almond-eyed Ringlet.
+  description: Species distribution models to predict the current and future distribution of the Almond-eyed Ringlet.
   categories: ['biogeography', 'ecology', 'intermediate', 'advanced']
 - title: Density distribution map of white-tailed deer
   path: https://ecodiv.earth/TutorialsNotes/deerdensities/index.html
   author: Paulo van Breugel
   image: content/tutorials/external/images/deer-density-tile.png
   date: "2025-01-10"
-  description: Creating a habitat suitability map for the white-tailed deer using spatial multicriteria analysis and spatial disaggregation in GRASS GIS.
+  description: Habitat suitability map for the white-tailed deer using spatial multicriteria analysis and spatial disaggregation in GRASS.
   categories: ['biogeography', 'MCDA', 'ecology', 'intermediate']
 - title: From suitability to suitable regions
   path: https://ecodiv.earth/TutorialsNotes/SuitabilityRegions/index.html
   author: Paulo van Breugel
   image: content/tutorials/external/images/suitability-regions-tile.png
   date: "2024-05-25"
-  description: In this tutorial you learn how you can identify and map regions with user defined minimum suitability scores and area size, using as input a suitability map.
+  description: Use a suitability map to identify and map regions with defined minimum suitability scores and area size.
   categories: ['biogeography', 'MCDA', 'ecology', 'beginner']
 - title: Tree species diversity distribution
   path: https://ecodiv.earth/post/tree-species-diversity-distribution/
   author: Paulo van Breugel
   image: content/tutorials/external/images/tree-diversity-tile.png
   date: "2020-07-29"
-  description: This tutorial shows you how to create maps of the tree species diversity across the contiguous USA, using various diversity indices, such as the species richness, Shannon index, Simpson index and the Shannon based effective number of species (ENS).
+  description: Create maps of tree species diversity across the contiguous USA, using various diversity indices.
   categories: ['biodiversity', 'geobiogeography', 'ecology', 'beginner']

--- a/content/tutorials/external/opengeohub2019.qmd
+++ b/content/tutorials/external/opengeohub2019.qmd
@@ -9,13 +9,10 @@ format:
     code-copy: true
     code-fold: false
 categories: [external, beginner, intermediate, R, ecology, rgrass, Python, time series]
+description: Series of tutorials on time series processing for environmental modeling delivered at OpenGeoHub summer school 2019.
 execute: 
   eval: false
 ---
-
-This is a series of tutorials on GRASS GIS for environmental modeling delivered at OpenGeoHub 2019.
-
-Authors: Verónica Andreo
 
 # Time series processing for environmental monitoring
 <https://github.com/veroandreo/grass_opengeohub2019/blob/master/pdf/tgrass_lst.pdf>

--- a/content/tutorials/external/point_clouds.qmd
+++ b/content/tutorials/external/point_clouds.qmd
@@ -9,11 +9,12 @@ format:
     code-copy: true
     code-fold: false
 categories: [external, beginner, intermediate, lidar]
+description: Hands-on workshop delivered at FOSS4G Boston 2017 showcasing GRASS tools for processing point clouds.
 execute: 
   eval: false
 ---
 
-This hands-on workshop, delivered at FOSS4G Boston 2017, showcases the tools in GRASS GIS for processing point clouds obtained by lidar or through processing of UAV imagery. It explores the properties of the point cloud, interpolate surfaces, and perform advanced terrain analyses to detect landforms and artifacts. The workshop will go through several terrain 2D and 3D visualization techniques to get more information out of the data and finish with vegetation analysis.
+This hands-on workshop, delivered at FOSS4G Boston 2017, showcases the tools in GRASS for processing point clouds obtained by lidar or through processing of UAV imagery. It explores the properties of the point cloud, interpolate surfaces, and perform advanced terrain analyses to detect landforms and artifacts. The workshop will go through several terrain 2D and 3D visualization techniques to get more information out of the data and finish with vegetation analysis.
 
 Authors: Vaclav Petras, Anna Petrasova, and Helena Mitasova from North Carolina State University
 

--- a/content/tutorials/external/portuguese_resources_Grohmann.qmd
+++ b/content/tutorials/external/portuguese_resources_Grohmann.qmd
@@ -10,19 +10,19 @@ format:
     code-copy: true
     code-fold: false
 categories: [beginner, intermediate, external, Portuguese]
-description: Tutoriais GRASS GIS em português
+description: Tutoriais GRASS em português.
 execute: 
   eval: false
 ---
 
 * [Curso - Introdução ao SIG com Software Livre (GRASS) (2021)](http://carlosgrohmann.com/downloads/sigcomsl_dados/aula_intro_grass_2021.pdf)
 
-* [Playlist de aulas sobre GRASS-GIS](https://www.youtube.com/playlist?list=PL9GztlLGb7RovKMMO2ohYdfxfILXjxwEy)
+* [Playlist de aulas sobre GRASS](https://www.youtube.com/playlist?list=PL9GztlLGb7RovKMMO2ohYdfxfILXjxwEy)
 
-* [Geoprocessamento com GRASS-GIS (2016)](https://figshare.com/articles/Geoprocessamento_com_GRASS-GIS/3502184)
+* [Geoprocessamento com GRASS (2016)](https://figshare.com/articles/Geoprocessamento_com_GRASS-GIS/3502184)
 
-* [Geoprocessamento com Software Livre: GRASS-GIS e QGIS (2012)](https://figshare.com/articles/Geoprocessamento_com_Software_Livre_GRASS_GIS_e_QGIS/1004167)
+* [Geoprocessamento com Software Livre: GRASS e QGIS (2012)](https://figshare.com/articles/Geoprocessamento_com_Software_Livre_GRASS_GIS_e_QGIS/1004167)
 
-* [Introdução à Análise Digital de Terreno com GRASS-GIS (2008)](https://figshare.com/articles/Introdu_o_An_lise_Digital_de_Terreno_com_GRASS_GIS/1004165)
+* [Introdução à Análise Digital de Terreno com GRASS (2008)](https://figshare.com/articles/Introdu_o_An_lise_Digital_de_Terreno_com_GRASS_GIS/1004165)
 
 ![](images/grohmann_3D.png){.preview-image}

--- a/content/tutorials/external/spanish_resources_Vero.qmd
+++ b/content/tutorials/external/spanish_resources_Vero.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Teledeteccion, OBIA y series de tiempo"
+title: "Teledetección, OBIA y series de tiempo"
 lang: es
 date: 01/01/2021
 author: Verónica Andreo
@@ -10,19 +10,17 @@ format:
     code-copy: true
     code-fold: false
 categories: [beginner, intermediate, external, Spanish]
-description: Procesamiento y análisis de datos espaciales en GRASS GIS
+description: Curso de postgrado sobre procesamiento y análisis de datos satelitales y series temporales con GRASS.
 execute: 
   eval: false
 ---
 
-Este taller abordará el procesamiento y análisis de datos
-espacio-temporales con uno de los Sistemas de Información Geográfica (SIG) de código abierto más populares: GRASS GIS 7 .
+Curso de postgrado dictado en la Universidad Nacional de Córdoba (UNC) que aborda el procesamiento de datos satelitales y series de tiempo
+para el modelado y análisis ecológicos y ambientales utilizando GRASS.
 
-Durante este taller los participantes obtendrán una visión general de las capacidades de GRASS GIS y experiencia práctica en procesamiento de datos raster, vectoriales y series de tiempo de productos satelitales para análisis ecológicos y ambientales.
+El curso es mayormente práctico y puede ejecutarse completamente con Jupyter Notebooks en Google Colab.
 
-El taller está dirigido a profesionales y técnicos con experiencia en el área de la geomática que quieran abordar una introducción al software GRASS GIS para realizar procesamiento y análisis de datos espaciales.
-
-<https://gitlab.com/veroandreo/maie-procesamiento/-/tree/taller-grass-online>
+<https://veroandreo.github.io/curso-grass-gis/>
 
 Autora: Dra. Verónica Andreo
 

--- a/content/tutorials/external/spanish_resources_wiki.qmd
+++ b/content/tutorials/external/spanish_resources_wiki.qmd
@@ -9,15 +9,15 @@ format:
     code-copy: true
     code-fold: false
 categories: [beginner, intermediate, external, Spanish]
-description: Tutoriales de GRASS GIS en grasswiki traducidos al español
+description: Tutoriales de GRASS en grasswiki traducidos al español.
 execute: 
   eval: false
 ---
 
 
-* [Visualizacion analitica de datos](https://grasswiki.osgeo.org/wiki/Analytical_data_visualizations_at_ICC_2017/es) (2017)
+* [Visualización analítica de datos](https://grasswiki.osgeo.org/wiki/Analytical_data_visualizations_at_ICC_2017/es) (2017)
 * [Libera el poder de GRASS GIS](https://grasswiki.osgeo.org/wiki/Unleash_the_power_of_GRASS_GIS_at_US-IALE_2017/es) (2017)
-* [Procesamiento de datos LiDAR y de UAV](https://grasswiki.osgeo.org/wiki/Processing_lidar_and_UAV_point_clouds_in_GRASS_GIS_(workshop_at_FOSS4G_Boston_2017)/es) (2017)
+* [Procesamiento de datos LiDAR y UAV](https://grasswiki.osgeo.org/wiki/Processing_lidar_and_UAV_point_clouds_in_GRASS_GIS_(workshop_at_FOSS4G_Boston_2017)/es) (2017)
 * [Procesamiento de series de tiempo con GRASS y R](https://grasswiki.osgeo.org/wiki/Temporal_data_processing/GRASS_R_raster_time_series_processing/es) (2017)
 
 ![](images/Different_terrain_analyses_and_visualizations_in_multiple_Map_Displays.png){.preview-image}

--- a/content/tutorials/external/spatio-temporal_visualization.qmd
+++ b/content/tutorials/external/spatio-temporal_visualization.qmd
@@ -9,12 +9,12 @@ format:
     code-copy: true
     code-fold: false
 categories: [external, intermediate, visualization, time series]
-description: This is a FOSS4G 2014 workshop on GRASS GIS time series data handling and visualization.
+description: This is a FOSS4G 2014 workshop on GRASS time series data handling and visualization.
 execute: 
   eval: false
 ---
 
-This is a FOSS4G 2014 workshop on GRASS GIS time series data handling and visualization, featuring analysis and visualization of climate data, terrain time series and solar radiation modeling.
+This is a FOSS4G 2014 workshop on GRASS time series data handling and visualization, featuring analysis and visualization of climate data, terrain time series and solar radiation modeling.
 
 <https://ncsu-geoforall-lab.github.io/grass-temporal-workshop/>
 

--- a/content/tutorials/external/unleash_the_power_of_GRASS_GIS.qmd
+++ b/content/tutorials/external/unleash_the_power_of_GRASS_GIS.qmd
@@ -9,11 +9,12 @@ format:
     code-copy: true
     code-fold: false
 categories: [beginner, intermediate, GUI, Google Colab, Python, external]
+description: Series of tutorials delivered at different events addressing begginer and intermediate geospatial data processing in GRASS with Jupyter notebooks.
 execute: 
   eval: false
 ---
 
-In this workshop, delivered at FOSS4G NA 2023, we explain and practice GRASS GIS concepts like computational region or mask and demonstrate them on examples of efficient raster, vector, and imagery processing. The workshop runs in a JupyterLab environment, introducing Python scripting for workflow automation. We also take advantage of the latest GRASS GIS Python features for Jupyter, including 2D, 3D, web map, and temporal visualizations. This workshop is suitable for both new and experienced GRASS GIS users. While you can run the workshop locally if desired, you can also use a cloud environment so no installation is required.
+In this workshop, delivered at FOSS4G NA 2023, we explain and practice GRASS concepts like computational region or mask and demonstrate them on examples of efficient raster, vector, and imagery processing. The workshop runs in a JupyterLab environment, introducing Python scripting for workflow automation. We also take advantage of the latest GRASS GIS Python features for Jupyter, including 2D, 3D, web map, and temporal visualizations. This workshop is suitable for both new and experienced GRASS GIS users. While you can run the workshop locally if desired, you can also use a cloud environment so no installation is required.
 
 Workshop instructions and material:\
 <https://github.com/ncsu-geoforall-lab/grass-gis-workshop-foss4gna-2023>
@@ -27,7 +28,6 @@ This workshop has been offered several times:
 * [workshop](https://github.com/ncsu-geoforall-lab/grass-gis-workshop-vanderbilt-2024) at Vanderbilt university (2024)
 * [workshop](https://github.com/ncsu-geoforall-lab/grass-gis-workshop-foss4g-2022) at FOSS4G 2022
 * [workshop](https://github.com/ncsu-geoforall-lab/grass-gis-workshop-FOSS4G-2021) at FOSS4G 2021
-
 * [workshop](https://grasswiki.osgeo.org/wiki/From_GRASS_GIS_novice_to_power_user_(workshop_at_FOSS4G_Boston_2017)) at FOSS4G 2017
 
 # Authors

--- a/content/tutorials/good_looking_plots/good_looking_plots_in_grass.qmd
+++ b/content/tutorials/good_looking_plots/good_looking_plots_in_grass.qmd
@@ -12,6 +12,7 @@ format:
     code-copy: true
     code-fold: false
 categories: [statistics, matplotlib, beginner]
+description: Quick review of tools to make plots for raster, vector and time series data in GRASS.
 engine: jupyter
 execute: 
   eval: false

--- a/content/tutorials/r_python_interfaces_comparison/quick_comparison_r_vs_python_grass_interfaces.qmd
+++ b/content/tutorials/r_python_interfaces_comparison/quick_comparison_r_vs_python_grass_interfaces.qmd
@@ -11,6 +11,7 @@ format:
     code-copy: true
     code-fold: false
 categories: [Python, R, intermediate]
+description: Comparison of R and Python GRASS interfaces to streamline the use of GRASS within R and Python communities
 engine: knitr
 execute:
   eval: false

--- a/theme.scss
+++ b/theme.scss
@@ -612,6 +612,11 @@ ul.pagination li.active a {
   color: $gs-secondary-alt-color;
 }
 
+/* Hide description on tutorial pages */
+.quarto-title-block .description {
+  display: none;
+}
+
 /* Table of Contents
 -----------------------------------------------------------------------------*/
 .sidebar nav[role=doc-toc]>h2 {


### PR DESCRIPTION
I fixed the display of the description tag to appear only when tutorials are listed on the home page. I also fixed several descriptions and removed "GIS" from GRASS name when I saw it. 

Fixes #35.