### PR TITLE
Sync footer icons order with website

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -31,27 +31,28 @@ website:
       - icon: opencollective
         href: https://opencollective.com/grass/contribute
         aria-label: GRASS on Open Collective
-      - text: "{{< fa brands gitter >}}"
-        href: https://gitter.im/grassgis/community
-        aria-label: GRASS on Gitter
-      - text: "{{< fa brands mastodon >}}"
-        href: https://fosstodon.org/@grassgis
-        aria-label: GRASS on Mastodon
+      - text: "{{< fa brands github >}}"
+        href: https://github.com/OSGeo/grass
+        aria-label: GRASS on GitHub
       - text: "{{< fa brands discourse >}}"
         href: https://discourse.osgeo.org/c/grass/62
         aria-label: GRASS on Discourse
+      - text: "{{< fa brands gitter >}}"
+        href: https://gitter.im/grassgis/community
+        aria-label: GRASS on Gitter
       - text: "{{< fa brands linkedin >}}"
         href: "https://linkedin.com/company/grass-gis"
         aria-label: GRASS on LinkedIn
+      - text: "{{< fa brands mastodon >}}"
+        href: https://fosstodon.org/@grassgis
+        aria-label: GRASS on Mastodon
       - text: "{{< fa brands x-twitter >}}"
         href: https://x.com/grassgis
         aria-label: GRASS on X
       - text: "{{< fa brands youtube >}}"
         href: https://www.youtube.com/@grass-gis
         aria-label: GRASS on YouTube
-      - text: "{{< fa brands github >}}"
-        href: https://github.com/OSGeo/grass
-        aria-label: GRASS on GitHub
+
 
   margin-header	: |
     [{{< fa heart >}} Support GRASS]({{< var grass.support >}}){.btn .btn-outline-support .btn role="button" align="center"}


### PR DESCRIPTION
This PR intends to sync the icons within the footer to those on the GRASS website. For now, only the reordering is addressed, but I'd like to sync the behavior also.

![image](https://github.com/user-attachments/assets/969511f9-408f-42e8-b0c0-9b3220f13853)
