### PR TITLE
fix broken links in earthworks/*.qmd files

### DIFF
--- a/content/tutorials/earthworks/basics.qmd
+++ b/content/tutorials/earthworks/basics.qmd
@@ -66,7 +66,7 @@ This tutorial covers:
 This tutorial can be run as a 
 [computational notebook](https://grass-tutorials.osgeo.org/content/tutorials/earthworks/basics.ipynb).
 Learn how to work with notebooks with the tutorial
-[Get started with GRASS & Python in Jupyter Notebooks](./../../get_started/fast_track_grass_and_python.qmd).
+[Get started with GRASS & Python in Jupyter Notebooks](../get_started/fast_track_grass_and_python.qmd).
 :::
 
 # Setup

--- a/content/tutorials/earthworks/gullies.qmd
+++ b/content/tutorials/earthworks/gullies.qmd
@@ -80,7 +80,7 @@ try the landscape evolution model
 This tutorial can be run as a 
 [computational notebook](https://grass-tutorials.osgeo.org/content/tutorials/earthworks/gullies.ipynb).
 Learn how to work with notebooks in the tutorial
-[Get started with GRASS & Python in Jupyter Notebooks](./../../get_started/fast_track_grass_and_python.qmd).
+[Get started with GRASS & Python in Jupyter Notebooks](../get_started/fast_track_grass_and_python.qmd).
 :::
 
 # Setup

--- a/content/tutorials/earthworks/levees.qmd
+++ b/content/tutorials/earthworks/levees.qmd
@@ -63,7 +63,7 @@ This tutorial covers:
 This tutorial can be run as a 
 [computational notebook](https://grass-tutorials.osgeo.org/content/tutorials/earthworks/levees.ipynb).
 Learn how to work with notebooks in the tutorial
-[Get started with GRASS & Python in Jupyter Notebooks](./../../get_started/fast_track_grass_and_python.qmd).
+[Get started with GRASS & Python in Jupyter Notebooks](../get_started/fast_track_grass_and_python.qmd).
 :::
 
 # Setup

--- a/content/tutorials/earthworks/synthesis.qmd
+++ b/content/tutorials/earthworks/synthesis.qmd
@@ -72,7 +72,7 @@ Terrain Synthesis
 This tutorial can be run as a 
 [computational notebook](https://grass-tutorials.osgeo.org/content/tutorials/earthworks/synthesis.ipynb).
 Learn how to work with notebooks with the tutorial
-[Get started with GRASS & Python in Jupyter Notebooks](./../../get_started/fast_track_grass_and_python.qmd).
+[Get started with GRASS & Python in Jupyter Notebooks](../get_started/fast_track_grass_and_python.qmd).
 :::
 
 # Setup


### PR DESCRIPTION
Fixes broken links introduced in https://github.com/OSGeo/grass-tutorials/pull/87 because I didn't go far enough up through the path.

This does not fix the issue of the 'computational notebook' link to a Jupyter Notebook in the browser.