### PR TITLE
tutorials: fix some typos

### DIFF
--- a/content/tests/styling.qmd
+++ b/content/tests/styling.qmd
@@ -591,7 +591,7 @@ This is a caution callout.
 :::
 ```
 
-### Collapsable Callout
+### Collapsible Callout
 
 ::: {.callout-caution collapse="true"}
 ## Expand To Learn About Collapse
@@ -977,7 +977,7 @@ Lipsum shortcode docs found [here](https://quarto.org/docs/authoring/lipsum.html
 
 # Custom
 
-Quarto supports several shortcodes natively which allow us to access project varibles.
+Quarto supports several shortcodes natively which allow us to access project variables.
 
 | Shortcode                                                     | Description                              |
 |---------------------------------------------------------------|------------------------------------------|
@@ -989,7 +989,7 @@ Quarto supports several shortcodes natively which allow us to access project var
 
 ## Variables
 
-You can access variables located in `_variables.yml` using pre-defined [varible shortcodes](https://quarto.org/docs/authoring/variables.html).
+You can access variables located in `_variables.yml` using pre-defined [variable shortcodes](https://quarto.org/docs/authoring/variables.html).
 
 ``` {.markdown shortcodes="false"}
 {{< var grass.website >}}

--- a/content/tutorials/external/unleash_the_power_of_GRASS_GIS.qmd
+++ b/content/tutorials/external/unleash_the_power_of_GRASS_GIS.qmd
@@ -9,7 +9,7 @@ format:
     code-copy: true
     code-fold: false
 categories: [beginner, intermediate, GUI, Google Colab, Python, external]
-description: Series of tutorials delivered at different events addressing begginer and intermediate geospatial data processing in GRASS with Jupyter notebooks.
+description: Series of tutorials delivered at different events addressing beginner and intermediate geospatial data processing in GRASS with Jupyter notebooks.
 execute: 
   eval: false
 ---

--- a/content/tutorials/get_started/fast_track_grass_and_python.qmd
+++ b/content/tutorials/get_started/fast_track_grass_and_python.qmd
@@ -95,7 +95,7 @@ This tutorial can be run locally. You need to have **GRASS 8.4+** and
 [Sentinel 2](https://grass.osgeo.org/sampledata/north_carolina/nc_sentinel_utm17n.zip)
 scenes and move the unzipped download into the directory where you are running
 this tutorial.
-For part B, we asume that you have downloaded the North Carolina
+For part B, we assume that you have downloaded the North Carolina
 [sample dataset](https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip),
 i.e., there's an existing GRASS project.
 Be sure you also have the following Python libraries installed in your

--- a/content/tutorials/get_started/grass_gis_in_google_colab.qmd
+++ b/content/tutorials/get_started/grass_gis_in_google_colab.qmd
@@ -108,7 +108,7 @@ import grass.jupyter as gj
 By default we have access to the `/content` folder within Colab, and any data we
 create and download will be placed there. We can change that of course, it is just a Linux
 file system. In any case, we should bare in mind that whatever data we download
-within Colab, will disappear if the runtime gets disconected because of inactivity
+within Colab, will disappear if the runtime gets disconnected because of inactivity
 or once we close the Colab session.
 :::
 
@@ -136,7 +136,7 @@ Now you can import data and start your analysis, following the
 # Start GRASS with a sample dataset
 
 If you want to learn data analysis with GRASS, instead of creating a new project from scratch,
-you can downlaod a ready-to-use sample dataset to play with.
+you can download a ready-to-use sample dataset to play with.
 
 ## Download sample data
 

--- a/content/tutorials/good_looking_plots/good_looking_plots_in_grass.qmd
+++ b/content/tutorials/good_looking_plots/good_looking_plots_in_grass.qmd
@@ -87,7 +87,7 @@ For more examples of the different options available in this addon, see [this tu
 
 `r.series.boxplot` draws boxplots of a series of input raster maps that might 
 represent different times, spectral bands in satellite imagery or other kind
-of variation. If users are interested in e.g., ploting the spectral signature
+of variation. If users are interested in e.g., plotting the spectral signature
 of different land cover classes, they can alternatively set masks and recreate
 the boxplot series. Let's see an example for developed and forested classes.
 

--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
@@ -533,7 +533,7 @@ In GRASS, remote sensing images are simply rasters, like DEM elevation maps or l
 
 For example, the a vector map of streams and lakes can be overlaid in the Layer Manager onto the image fusion of PCA components 1-3 created above.
 
-![Image fusion of PCA components 1, 2, & 3 overlayed by streams and lakes vectors](img_remotesensing/PCA123_streams_lakes.webp){width="50%"}
+![Image fusion of PCA components 1, 2, & 3 overlaid by streams and lakes vectors](img_remotesensing/PCA123_streams_lakes.webp){width="50%"}
 
 
 # 3D visualization of remote sensing and GIS

--- a/theme.scss
+++ b/theme.scss
@@ -319,7 +319,7 @@ $important: false) {
   &::first-letter {
     text-transform: uppercase;
   }
-  // Insterted by Lua filter protect-terms
+  // Inserted by Lua filter protect-terms
   .no-transform,
   span.no-transform {
     text-transform: none !important;


### PR DESCRIPTION
Fix typos across the tree

(using https://github.com/OSGeo/grass/blob/main/utils/fix_typos.sh)