### PR TITLE
Update earthworking tutorials

### DIFF
--- a/content/tutorials/earthworks/gullies.qmd
+++ b/content/tutorials/earthworks/gullies.qmd
@@ -196,7 +196,6 @@ to scale it vertically so that the mountains are not too high.
 ```{bash}
 r.surf.fractal output=fractal seed=1
 r.mapcalc expression="fractal = fractal / 10" --overwrite
-r.stream.extract elevation=fractal accumulation=accumulation threshold=1000 stream_vector=streams
 ```
 
 ## Python

--- a/content/tutorials/earthworks/levees.qmd
+++ b/content/tutorials/earthworks/levees.qmd
@@ -272,7 +272,7 @@ would be overtopped by a meter of surge.
 ## Command line
 
 ```{bash}
-r.lake elevation=elevation water_level=1 lake=flooding coordinates=1109000,102750
+r.lake elevation=elevation water_level=1 lake=flooding coordinates=1109000,102750 --overwrite
 d.shade shade=relief color=elevation brighten=36
 d.rast map=flooding
 d.legend raster=flooding digits=1 color=white at=5,95,1,3
@@ -614,7 +614,7 @@ would be not overtopped by a meter of surge.
 ## Command line
 
 ```{bash}
-r.lake elevation=earthworks water_level=1 lake=flooding coordinates=1109000,102750
+r.lake elevation=earthworks water_level=1 lake=flooding coordinates=1109000,102750 --overwrite
 d.shade shade=relief color=earthworks brighten=36
 d.rast map=flooding
 d.legend raster=flooding digits=1 color=white at=5,95,1,3


### PR DESCRIPTION
Fixes issues in CLI commands raised by @micha-silver in https://github.com/baharmon/r.earthworks/issues/25 for earthworking tutorials.

> I came across two small problems with the tutorials:
In Gully Modeling, under the Fractal Terrain section, I believe that the accumulation=accumulation parameter should be removed. That (input) map does not yet exist, until after running r.watershed in the following code snippet.
In Modeling Coastal Infrastructure, I believe that --overwrite needs to be added in the Flood Simulation section and later in the final Flood Simulation section, since the lake raster exists in the original data.