### PR TITLE
Fix invalid tile name and stale versioned link in time series tutorials

### DIFF
--- a/content/tutorials/time_series/time_series_aggregations.qmd
+++ b/content/tutorials/time_series/time_series_aggregations.qmd
@@ -228,7 +228,7 @@ gs.run_command("t.rast.series",
                method="average")
                
 # Display raster map with interactive class
-spw_map = gj.InteractiveMap(width = 500, use_region=True, tiles="CartoDark")
+spw_map = gj.InteractiveMap(width = 500, use_region=True, tiles="CartoDB.DarkMatter")
 spw_map.add_raster("avg_spring_warming")
 spw_map.add_layer_control(position = "bottomright")
 spw_map.show()

--- a/content/tutorials/time_series/time_series_aggregations.qmd
+++ b/content/tutorials/time_series/time_series_aggregations.qmd
@@ -45,14 +45,14 @@ import subprocess
 
 # Ask GRASS where its Python packages are
 sys.path.append(
-    subprocess.check_output([grassbin, "--config", "python_path"], text=True).strip()
+    subprocess.check_output(["grass", "--config", "python_path"], text=True).strip()
 )
 
 # Import the GRASS packages we need
 import grass.script as gs
 import grass.jupyter as gj
 
-path_to_project = "eu_laea/italy_LST_daily"
+path_to_project = "italy_eu_laea/italy_LST_daily"
 
 # Start the GRASS session
 session = gj.init(path_to_project);

--- a/content/tutorials/time_series/time_series_aggregations.qmd
+++ b/content/tutorials/time_series/time_series_aggregations.qmd
@@ -43,11 +43,9 @@ import os
 import sys
 import subprocess
 
-grassbin = "grass"  # change if your GRASS binary has a different name or path
-
 # Ask GRASS where its Python packages are
 sys.path.append(
-    subprocess.check_output([grassbin, "--config", "python_path"], text=True).strip()
+    subprocess.check_output(["grass", "--config", "python_path"], text=True).strip()
 )
 
 # Import the GRASS packages we need

--- a/content/tutorials/time_series/time_series_aggregations.qmd
+++ b/content/tutorials/time_series/time_series_aggregations.qmd
@@ -43,9 +43,11 @@ import os
 import sys
 import subprocess
 
+grassbin = "grass"  # change if your GRASS binary has a different name or path
+
 # Ask GRASS where its Python packages are
 sys.path.append(
-    subprocess.check_output(["grass", "--config", "python_path"], text=True).strip()
+    subprocess.check_output([grassbin, "--config", "python_path"], text=True).strip()
 )
 
 # Import the GRASS packages we need

--- a/content/tutorials/time_series/time_series_management_and_visualization.qmd
+++ b/content/tutorials/time_series/time_series_management_and_visualization.qmd
@@ -267,7 +267,7 @@ can create this file for you when you import data into GRASS.
 
 ::: {.callout-note}
 Have a look at the 
-<a href="https://grass.osgeo.org/grass83/manuals/t.register.html">t.register</a> 
+<a href="https://grass.osgeo.org/grass-stable/manuals/t.register.html">t.register</a> 
 manual page and a dedicated 
 [wiki](https://grasswiki.osgeo.org/wiki/Temporal_data_processing/maps_registration) 
 with further examples.
@@ -294,7 +294,7 @@ and observe topological relationships among STDS.
 
 #### Temporal plot for Trento, Italy
 
-The temporal plot tool, [`g.gui.tplot`](https://grass.osgeo.org/grass83/manuals/g.gui.tplot.html),
+The temporal plot tool, [`g.gui.tplot`](https://grass.osgeo.org/grass-stable/manuals/g.gui.tplot.html),
 allows to plot the time series values of raster or vector space-time
 datasets. In this case, we will plot the LST time series for the city of
 Trento, Italy. 
@@ -424,7 +424,7 @@ same filtering can be applied in tools to determine maps that will be processed.
 
 ### Descriptive statistics
 
-The tool [`t.rast.univar`](https://grass.osgeo.org/grass-stable/manuals/t.vect.univar.html)
+The tool [`t.rast.univar`](https://grass.osgeo.org/grass-stable/manuals/t.rast.univar.html)
 calculates univariate statistics from the non-null cells of each raster
 map within STRDS.
 By default it returns the name of the map, the start and end date of the 

--- a/content/tutorials/time_series/time_series_query_with_vector.qmd
+++ b/content/tutorials/time_series/time_series_query_with_vector.qmd
@@ -306,7 +306,7 @@ need aggregated values for a set of points.
 
 :::{.callout-note}
 We could have also used
-[t.sample](https://grass.osgeo.org/grass84/manuals/t.sample.html)
+[t.sample](https://grass.osgeo.org/grass-stable/manuals/t.sample.html)
 to check which maps from `lst_daily` would be aggregated in the
 new column `lst_new` above.
 


### PR DESCRIPTION
### Two small fixes in time series tutorials:

* In `time_series_aggregations.qmd` (L231), `tiles="CartoDark"` isn't a valid `grass.jupyter` tile name. I updated it to `tiles="CartoDB.DarkMatter"`, which matches the usage in the other tutorials in the series.

* In `time_series_query_with_vector.qmd` (L309), the `t.sample` documentation link pointed to the version-specific `grass84` manual. I updated it to use the `grass-stable` manual instead.
