### PR TITLE
Fix broken i.pca command in remote sensing tutorials

### DIFF
--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
@@ -436,7 +436,7 @@ Here, we will explore **principal components analysis** (PCA). PCA mathematicall
 Perform a PCA and output the results to the console/terminal and as PCA component maps.  
 
 ```{bash}
-i.pca input=landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4, landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7 output=Flagstaff_landsat8
+i.pca input=landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4,landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7 output=Flagstaff_landsat8
 ```
 
 #### Python
@@ -444,9 +444,9 @@ i.pca input=landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4, landsat8_2024_B5
 Perform a PCA and output the results to the console/terminal and as PCA component maps.  
 
 ```{python}
-gs.run_command("i.pca", 
-                input="landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4, landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7", 
-                output=Flagstaff_landsat8)
+gs.run_command("i.pca",
+                input="landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4,landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7",
+                output="Flagstaff_landsat8")
 ```
 
 ::::::

--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_pt.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_pt.qmd
@@ -425,7 +425,7 @@ Aqui, exploraremos a **análise de componentes principais (PCA)**. A PCA combina
 Realize uma PCA e exiba os resultados no console/terminal e como mapas de componentes da PCA.  
 
 ```{bash}
-i.pca input=landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4, landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7 output=Flagstaff_landsat8
+i.pca input=landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4,landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7 output=Flagstaff_landsat8
 ```
 
 #### Python
@@ -433,9 +433,9 @@ i.pca input=landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4, landsat8_2024_B5
 Realize uma PCA e exiba os resultados no console/terminal e como mapas de componentes da PCA.  
 
 ```{python}
-gs.run_command("i.pca", 
-                input="landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4, landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7", 
-                output=Flagstaff_landsat8)
+gs.run_command("i.pca",
+                input="landsat8_2024_B2,landsat8_2024_B3,landsat8_2024_B4,landsat8_2024_B5,landsat8_2024_B6,landsat8_2024_B7",
+                output="Flagstaff_landsat8")
 ```
 ::::::
 


### PR DESCRIPTION
Fixes #104

This PR fixes two issues in the PCA section of both the English and Portuguese remote sensing tutorials:

1. **Trailing space in input list** – `landsat8_2024_B4, landsat8_2024_B5` (note the space after the comma) causes `i.pca` to fail in both the CLI and Python examples.
2. **Missing quotes around the output parameter** – `output=Flagstaff_landsat8` in the Python example references an undefined variable instead of the string `"Flagstaff_landsat8"`, resulting in a `NameError`.

The fixes have been applied to:

* `GRASS_remotesensing.qmd`
* `GRASS_remotesensing_pt.qmd`

These changes ensure that all PCA examples run successfully as written.
