### PR TITLE
Fix engine typo: knitter → knitr in terrain and movement tutorials

### DIFF
--- a/content/tutorials/modeling_movement/GRASS_movement.qmd
+++ b/content/tutorials/modeling_movement/GRASS_movement.qmd
@@ -4,7 +4,7 @@ author: "Michael Barton & Anna Petrasova"
 date: 2025-02-10
 date-modified: today
 lightbox: true
-engine: knitter
+engine: knitr
 image: img_movement/thumbnail.webp
 format: 
   html:

--- a/content/tutorials/modeling_movement/GRASS_movement_pt.qmd
+++ b/content/tutorials/modeling_movement/GRASS_movement_pt.qmd
@@ -4,7 +4,7 @@ author: "Michael Barton, Letícia Correa, e Anna Petrasova"
 date: 2025-05-09
 date-modified: today
 lightbox: true
-engine: knitter
+engine: knitr
 image: img_movement/thumbnail.webp
 format: 
   html:

--- a/content/tutorials/terrain_and_DEMs/GRASS_terrain.qmd
+++ b/content/tutorials/terrain_and_DEMs/GRASS_terrain.qmd
@@ -4,7 +4,7 @@ author: "Eunice Villaseñor Iribe and Michael Barton"
 date: 2025-06-23
 date-modified: today
 lightbox: true
-engine: knitter
+engine: knitr
 image: img_terrain/thumbnail.webp
 format: 
   html:

--- a/content/tutorials/terrain_and_DEMs/GRASS_terrain_pt.qmd
+++ b/content/tutorials/terrain_and_DEMs/GRASS_terrain_pt.qmd
@@ -4,7 +4,7 @@ author: "Eunice Villaseñor Iribe, Michael Barton, & Leticia Correa"
 date: 2025-06-23
 date-modified: today
 lightbox: true
-engine: knitter
+engine: knitr
 image: img_terrain/thumbnail.webp
 format: 
   html:


### PR DESCRIPTION
Four tutorials had `engine: knitter` (misspelling) instead of `engine: knitr`. Quarto does not recognise `knitter` as a valid engine and silently falls back to a default.

Affected files:
- `terrain_and_DEMs/GRASS_terrain.qmd`
- `terrain_and_DEMs/GRASS_terrain_pt.qmd`
- `modeling_movement/GRASS_movement.qmd`
- `modeling_movement/GRASS_movement_pt.qmd`

The same typo in `remote_sensing_visualization/GRASS_remotesensing.qmd` is addressed separately in PR #125.