### PR TITLE
Fix missing quotes on Python parameters in remote sensing tutorials

### DIFF
--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
@@ -195,28 +195,28 @@ r.colors -e map=landsat8_2024_B7 color=grey
 
 ```{python}
 gs.run_command("r.colors",
-               map=landsat8_2024_B2,
-               color=grey,
+               map="landsat8_2024_B2",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B3,
-               color=grey,
+               map="landsat8_2024_B3",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B4,
-               color=grey,
+               map="landsat8_2024_B4",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B5,
-               color=grey,
+               map="landsat8_2024_B5",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B6,
-               color=grey,
+               map="landsat8_2024_B6",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B7,
-               color=grey,
+               map="landsat8_2024_B7",
+               color="grey",
                flags="e")
                
 ```
@@ -388,11 +388,11 @@ i.vi output=Flagstaff_NDVI viname=ndvi red=landsat8_2024_B4 nir=landsat8_2024_B5
 ```{python}
 gs.run_command("g.region", raster="landsat8_2024_B2")
 
-gs.run_command("i.vi", 
-                output=Flagstaff_NDVI, 
-                viname=ndvi, 
-                red=landsat8_2024_B4, 
-                nir=landsat8_2024_B5
+gs.run_command("i.vi",
+                output="Flagstaff_NDVI",
+                viname="ndvi",
+                red="landsat8_2024_B4",
+                nir="landsat8_2024_B5"
   )
 ```
 

--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_pt.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_pt.qmd
@@ -194,28 +194,28 @@ r.colors -e map=landsat8_2024_B7 color=grey
 
 ```{python}
 gs.run_command("r.colors",
-               map=landsat8_2024_B2,
-               color=grey,
+               map="landsat8_2024_B2",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B3,
-               color=grey,
+               map="landsat8_2024_B3",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B4,
-               color=grey,
+               map="landsat8_2024_B4",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B5,
-               color=grey,
+               map="landsat8_2024_B5",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B6,
-               color=grey,
+               map="landsat8_2024_B6",
+               color="grey",
                flags="e")
 gs.run_command("r.colors",
-               map=landsat8_2024_B7,
-               color=grey,
+               map="landsat8_2024_B7",
+               color="grey",
                flags="e")
                
 ```
@@ -379,11 +379,11 @@ i.vi output=Flagstaff_NDVI viname=ndvi red=landsat8_2024_B4 nir=landsat8_2024_B5
 ```{python}
 gs.run_command("g.region", raster="landsat8_2024_B2")
 
-gs.run_command("i.vi", 
-                output=Flagstaff_NDVI, 
-                viname=ndvi, 
-                red=landsat8_2024_B4, 
-                nir=landsat8_2024_B5
+gs.run_command("i.vi",
+                output="Flagstaff_NDVI",
+                viname="ndvi",
+                red="landsat8_2024_B4",
+                nir="landsat8_2024_B5"
   )
 ```
 :::::::::


### PR DESCRIPTION
The remote sensing tutorials (EN and PT) had 16 unquoted string parameters in two Python code blocks : `r.colors` and `i.vi`,  that would raise `NameError` when executed.

**`r.colors` block** (×6 calls in each file):
- `map=landsat8_2024_B2` → `map="landsat8_2024_B2"`
- `color=grey` → `color="grey"`

**`i.vi` block**:
- `output=Flagstaff_NDVI` → `output="Flagstaff_NDVI"`
- `viname=ndvi` → `viname="ndvi"`
- `red=landsat8_2024_B4` → `red="landsat8_2024_B4"`
- `nir=landsat8_2024_B5` → `nir="landsat8_2024_B5"`

Applied to both `GRASS_remotesensing.qmd` and `GRASS_remotesensing_pt.qmd`. The `i.pca` quoting fix in the same files is covered separately in PR #125.