### PR TITLE
Fix engine typo: knitter → knitr in remote sensing tutorial

### DIFF
--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
@@ -5,7 +5,7 @@ date: 2025-05-21
 date-modified: today
 image: img_remotesensing/thumbnail.webp
 lightbox: true
-engine: knitter
+engine: knitr
 format: 
   html:
     embed-resources: true


### PR DESCRIPTION
Fixes the remaining `engine: knitter` typo in `GRASS_remotesensing.qmd`. The same fix was applied to four other tutorials in PR #126 — this file was excluded at the time because PR #125 was open on it.