### PR TITLE
Reduce and consolidate tutorial categories (#73)

### DIFF
--- a/content/tutorials/external/ecodiv.qmd
+++ b/content/tutorials/external/ecodiv.qmd
@@ -8,7 +8,7 @@ format:
     code-tools: true
     code-copy: true
     code-fold: false
-categories: [beginner, intermediate, advanced, GUI, Python, R, external, ecology, statistics, visualization, biodiversity]
+categories: [beginner, intermediate, advanced, GUI, Python, R, external, ecology, statistics, visualization]
 description: GRASS tutorials on ecology and biogeography topics.
 execute: 
   eval: false

--- a/content/tutorials/external/ecodiv.yml
+++ b/content/tutorials/external/ecodiv.yml
@@ -4,25 +4,25 @@
   image: content/tutorials/external/images/sdm_in_grass_tutorialbanner.png
   date: "2025-02-12"
   description: Species distribution models to predict the current and future distribution of the Almond-eyed Ringlet.
-  categories: ['biogeography', 'ecology', 'intermediate', 'advanced', 'external']
+  categories: ['ecology', 'intermediate', 'advanced', 'external']
 - title: Density distribution map of white-tailed deer
   path: https://ecodiv.earth/TutorialsNotes/deerdensities/index.html
   author: Paulo van Breugel
   image: content/tutorials/external/images/deer-density-tile.png
   date: "2025-01-10"
   description: Habitat suitability map for the white-tailed deer using spatial multicriteria analysis and spatial disaggregation in GRASS.
-  categories: ['biogeography', 'MCDA', 'ecology', 'intermediate', 'external']
+  categories: ['ecology', 'intermediate', 'external']
 - title: From suitability to suitable regions
   path: https://ecodiv.earth/TutorialsNotes/SuitabilityRegions/index.html
   author: Paulo van Breugel
   image: content/tutorials/external/images/suitability-regions-tile.png
   date: "2024-05-25"
   description: Use a suitability map to identify and map regions with defined minimum suitability scores and area size.
-  categories: ['biogeography', 'MCDA', 'ecology', 'beginner', 'external']
+  categories: ['ecology', 'beginner', 'external']
 - title: Tree species diversity distribution
   path: https://ecodiv.earth/post/tree-species-diversity-distribution/
   author: Paulo van Breugel
   image: content/tutorials/external/images/tree-diversity-tile.png
   date: "2020-07-29"
   description: Create maps of tree species diversity across the contiguous USA, using various diversity indices.
-  categories: ['biodiversity', 'geobiogeography', 'ecology', 'beginner', 'external']
+  categories: ['ecology', 'beginner', 'external']

--- a/content/tutorials/external/huidae_courses.yml
+++ b/content/tutorials/external/huidae_courses.yml
@@ -4,11 +4,11 @@
   image: content/tutorials/external/images/deforestation_tutorial.png
   date: "2022-03-25"
   description: Estimate the forest change rate and learn some GRASS basic concepts.
-  categories: ['bash', 'Python', 'beginner', 'external']
+  categories: ['Bash', 'Python', 'beginner', 'external']
 - title: Physically-based hydrologic modeling using GRASS r.topmodel
   path: https://workshop.isnew.info/nsf-pose-2025-r.topmodel/
   author: Huidae Cho
   image: content/tutorials/external/images/subwatersheds-streams-watershed.png
   date: "2025-01-31"
   description: Workshop introducing the r.topmodel tool for hydrologic modeling.
-  categories: ['bash', 'R', 'intermediate', 'hydrology', 'external']
+  categories: ['Bash', 'R', 'intermediate', 'hydrology', 'external']

--- a/content/tutorials/hydro_flattening/hydro_flatenning.qmd
+++ b/content/tutorials/hydro_flattening/hydro_flatenning.qmd
@@ -15,7 +15,7 @@ format:
     code-tools: true
     code-copy: true
     code-fold: false
-categories: [Python, intermediate, topography, lidar, GUI]
+categories: [Python, intermediate, terrain, lidar, GUI]
 description: Learn how to do hydro-flattening of a DEM.
 engine: knitr
 execute:

--- a/content/tutorials/parallelization/SIMWE_parallelization.qmd
+++ b/content/tutorials/parallelization/SIMWE_parallelization.qmd
@@ -3,7 +3,7 @@ title: "Parallelization of overland flow and sediment transport simulation"
 author: "Anna Petrasova"
 date: 2025-09-25
 date-modified: today
-categories: [Python, advanced, parallelization, hydrology, erosion]
+categories: [Python, advanced, parallelization, hydrology]
 description: >
   In this tutorial we will run overland flow
   and erosion simulation (SIMWE) split by subwatersheds

--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing.qmd
@@ -14,7 +14,7 @@ format:
     code-copy: true
     code-fold: false
 page-layout: article
-categories: [beginner, GUI, imagery, remote sensing, visualization]
+categories: [beginner, GUI, remote sensing, visualization]
 description: Analysis and visualization of multi-band satellite imagery using image fusion, environmental indexes, and dimensionality reduction with principal components analysis.
 execute: 
   eval: false

--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_es.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_es.qmd
@@ -14,7 +14,7 @@ format:
     code-copy: true
     code-fold: false
 page-layout: article
-categories: [beginner, GUI, imagery, remote sensing, visualization, Spanish]
+categories: [beginner, GUI, remote sensing, visualization, Spanish]
 Description: Análisis y visualización de imágenes satelitales multibanda mediante fusión de imágenes, índices ambientales y reducción de dimensionalidad con análisis de componentes principales.
 execute: 
   eval: false

--- a/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_pt.qmd
+++ b/content/tutorials/remote_sensing_visualization/GRASS_remotesensing_pt.qmd
@@ -14,7 +14,7 @@ format:
     code-copy: true
     code-fold: false
 page-layout: article
-categories: [beginner, GUI, imagery, remote sensing, visualization, Portuguese]
+categories: [beginner, GUI, remote sensing, visualization, Portuguese]
 description: Análise e visualização de imagens de satélite multiespectrais utilizando fusão de imagens, índices ambientais e redução de dimensionalidade com análise de componentes principais.
 execute: 
   eval: false

--- a/content/tutorials/terrain_and_DEMs/GRASS_terrain.qmd
+++ b/content/tutorials/terrain_and_DEMs/GRASS_terrain.qmd
@@ -14,7 +14,7 @@ format:
     code-copy: true
     code-fold: false
 page-layout: article
-categories: [beginner, intermediate, raster, DEM, visualization, terrain, slope, aspect, landforms, hydrology, streams]
+categories: [beginner, intermediate, raster, visualization, terrain, hydrology]
 description: This tutorial guides a user through multiple ways of analyzing and modeling terrain from DEM raster maps.
 execute: 
   eval: false

--- a/content/tutorials/terrain_and_DEMs/GRASS_terrain_es.qmd
+++ b/content/tutorials/terrain_and_DEMs/GRASS_terrain_es.qmd
@@ -14,7 +14,7 @@ format:
     code-copy: true
     code-fold: false
 page-layout: article
-categories: [beginner, intermediate, raster, DEM, visualization, terrain, slope, aspect, landforms, hydrology, streams, Spanish]
+categories: [beginner, intermediate, raster, visualization, terrain, hydrology, Spanish]
 description: Este tutorial guía al usuario a través de múltiples formas de analizar y modelar terrenos a partir de mapas raster DEM.
 execute: 
   eval: false

--- a/content/tutorials/terrain_and_DEMs/GRASS_terrain_pt.qmd
+++ b/content/tutorials/terrain_and_DEMs/GRASS_terrain_pt.qmd
@@ -14,7 +14,7 @@ format:
     code-copy: true
     code-fold: false
 page-layout: article
-categories: [beginner, intermediate, raster, DEM, visualization, terrain, slope, aspect, landforms, hydrology, streams, Portuguese]
+categories: [beginner, intermediate, raster, visualization, terrain, hydrology, Portuguese]
 description: Este tutorial orienta o usuário por meio de várias maneiras de analisar e modelar terrenos a partir de mapas raster MDE.
 execute: 
   eval: false


### PR DESCRIPTION
Closes #73 (the consensus merges; see note below).

The listing sidebar had grown to **52 unique categories** across 60 tutorials, many of them near-duplicates, single-use tags, or the nonsense/mix-up terms flagged in #73. This trims the set to **39** by applying only the merges already agreed in that thread — no new terms introduced.

### Merges

| Removed | → Merged into | Rationale (from #73) |
|--------|--------------|----------------------|
| `MCDA` | *(deleted)* | @ecodiv confirmed it's a mix-up from an unsubmitted tutorial |
| `geobiogeography` | `ecology` | flagged as nonsense (`geo` already in bio-**geo**-graphy) |
| `biogeography`, `biodiversity` | `ecology` | @veroandreo: group ecology-adjacent terms |
| `DEM`, `topography`, `slope`, `aspect`, `landforms` | `terrain` | @petrasovaa: these "mean almost the same thing" |
| `streams`, `erosion` | `hydrology` | @petrasovaa: prefer the broad `hydrology` |
| `imagery` | `remote sensing` | @veroandreo: "merge into one" |
| `bash` → `Bash` | *(normalized)* | case duplicate; align with `Python`/`R` |

### Notes

- **No content changed** — only category frontmatter and the two external listing YAMLs (`ecodiv.yml`, `huidae_courses.yml`).
- Categories are auto-collected via `categories: true` in `index.qmd`, so there's nothing else to update.
- Because search is fulltext, the removed nuanced terms are still discoverable in the tutorial body.
- **Not included here** (left for discussion): further optional trimming (e.g. `least cost path`→`cost surface`, dropping single-use `coast`/`engineering`/`Landlab`, library tags like `NumPy`/`matplotlib`), and a curated category "menu" for `CONTRIBUTING`. Happy to follow up in a second PR if wanted.