### PR TITLE
Fix broken addon manual links (r.runoff, r.windfetch)

### DIFF
--- a/content/tutorials/parallelization/SIMWE_parallelization.qmd
+++ b/content/tutorials/parallelization/SIMWE_parallelization.qmd
@@ -534,7 +534,7 @@ We will then create an input precipitation depth raster, assuming uniform rainfa
 tools.r_mapcalc(expression=f"rainfall_{huc12} = {depth}")
 ```
 
-With that we estimate runoff (rainfall excess) with [r.runoff](https://grass.osgeo.org/grass-stable/manuals/r.runoff.html),
+With that we estimate runoff (rainfall excess) with [r.runoff](https://grass.osgeo.org/grass-stable/manuals/addons/r.runoff.html),
 which estimates for each cell total runoff depth in mm for the duration of the storm
 using SCS Curve Number method.
 

--- a/content/tutorials/windfetch/windfetch.qmd
+++ b/content/tutorials/windfetch/windfetch.qmd
@@ -26,7 +26,7 @@ jupyter: python3
 # Introduction
 
 Wind fetch — the distance wind blows across open water — is a key factor in wave generation and shoreline exposure. It is widely used in coastal engineering to estimate wave height, and in ecology to assess habitat vulnerability to wave energy. This tutorial demonstrates how to use the 
-[r.windfetch](https://grass.osgeo.org/grass-devel/manuals/r.windfetch.html) addon in GRASS to compute fetch lengths for a case study on the North Carolina coast.
+[r.windfetch](https://grass.osgeo.org/grass-stable/manuals/addons/r.windfetch.html) addon in GRASS to compute fetch lengths for a case study on the North Carolina coast.
 
 We will:
 


### PR DESCRIPTION
Two tutorials link to addon manuals at the core manual path, which returns 404. Both tools are addons, so their manual pages live under `manuals/addons/`.

- SIMWE parallelization: the `r.runoff` link
- Windfetch: the `r.windfetch` link

I pointed both at the `addons/` path and checked that they return 200.